### PR TITLE
fix: only use needed bevy features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 
 [dependencies]
-bevy = { version = "0.14", features = ["serialize"] }
+bevy = { version = "0.14", default-features = false, features = ["serialize", "bevy_winit"] }
 bevy-persistent = { version = "0.6" }
 serde = { version = "1.0", features = ["derive"] }
 winit = { version = "0.30", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = ["serialize", "bevy_winit"] }
+bevy = { version = "0.14", default-features = false, features = ["serialize", "bevy_winit", "x11"] }
 bevy-persistent = { version = "0.6" }
 serde = { version = "1.0", features = ["derive"] }
 winit = { version = "0.30", default-features = false }


### PR DESCRIPTION
Thanks for the convenient utility library! This PR just disables Bevy's default features and specifies the only ones that are needed to run.